### PR TITLE
update to Ubuntu Bionic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
-  glusterfs_version = "3.12"
+  config.vm.box = "ubuntu/bionic64"
+  glusterfs_version = "4.0"
   # We setup three nodes to be gluster hosts, and one gluster client to mount the volume
   (1..3).each do |i|
     config.vm.define vm_name = "gluster-server-#{i}" do |config|
@@ -11,9 +11,8 @@ Vagrant.configure("2") do |config|
       config.vm.hostname = vm_name
       ip = "172.21.12.#{i+10}"
       config.vm.network :private_network, ip: ip
-      config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq python-software-properties", :privileged => true
       config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:gluster/glusterfs-#{glusterfs_version}", :privileged => true
-      config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq glusterfs-server", :privileged => true
+      config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get install -yq glusterfs-server", :privileged => true
     end
   end
   config.vm.define vm_name = "gluster-client" do |config|
@@ -21,8 +20,7 @@ Vagrant.configure("2") do |config|
     config.vm.hostname = vm_name
     ip = "172.21.12.10"
     config.vm.network :private_network, ip: ip
-    config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq python-software-properties", :privileged => true
     config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:gluster/glusterfs-#{glusterfs_version}", :privileged => true
-    config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq glusterfs-client", :privileged => true
+    config.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get install -yq glusterfs-client", :privileged => true
   end
 end


### PR DESCRIPTION
- update box to ubuntu/bionic64
- remove unnecessary provisioning steps: bonioc box comes with
add-apt-repository
- set default glusterfs to 4.0

Signed-off-by: Santiago M. Mola <santi@mola.io>